### PR TITLE
Revert "Use `name` method instead of using temporary file"

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,8 +8,10 @@ st.sidebar.title("STL viewer")
 
 uploaded_file = st.file_uploader("Upload a STL:", ["stl"], False)
 if uploaded_file:
-    reader = pv.STLReader(uploaded_file.name)
-    mesh = reader.read()
+    with tempfile.NamedTemporaryFile(suffix=".stl") as fp:
+        fp.write(uploaded_file.getbuffer())
+        reader = pv.STLReader(fp.name)
+        mesh = reader.read()
 else:
     mesh = examples.download_bunny()
 


### PR DESCRIPTION
Reverts pyvista/streamlit-stlviewer#17